### PR TITLE
Update to sylabs v1.3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_and_test:
     name: build_and_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.18.x'
+          go-version: '1.19.x'
 
       - name: Check go.mod and go.sum are tidy
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45
+          version: v1.50
 
       - name: Run Lint
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    - deadcode
     - decorder
     - depguard
     - dogsled
@@ -28,11 +27,8 @@ linters:
     - nakedret
     - prealloc
     - revive
-    - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - typecheck
     - unused
-    - varcheck

--- a/client/models.go
+++ b/client/models.go
@@ -236,8 +236,9 @@ type ArchImageTag struct {
 
 // ArchTagMap is a mapping of a string architecture to a TagMap, and hence to
 // Images.
-// e.g. {
-//			"amd64":    { "latest": 507f1f77bcf86cd799439011 },
-//			"ppc64le":  { "latest": 507f1f77bcf86cd799439012 },
-//		}
+//
+//	e.g. {
+//				"amd64":    { "latest": 507f1f77bcf86cd799439011 },
+//				"ppc64le":  { "latest": 507f1f77bcf86cd799439012 },
+//			}
 type ArchTagMap map[string]TagMap

--- a/client/pull.go
+++ b/client/pull.go
@@ -104,9 +104,13 @@ type Downloader struct {
 
 // httpGetRangeRequest performs HTTP GET range request to URL specified by 'u' in range start-end.
 func (c *Client) httpGetRangeRequest(ctx context.Context, url string, start, end int64) (*http.Response, error) {
-	req, err := c.newRequestWithURL(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if v := c.UserAgent; v != "" {
+		req.Header.Set("User-Agent", v)
 	}
 
 	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", start, end))

--- a/client/ref.go
+++ b/client/ref.go
@@ -40,11 +40,11 @@ var (
 //
 // Examples of valid URIs:
 //
-//  library:path:tags
-//  library:/path:tags
-//  library:///path:tags
-//  library://host/path:tags
-//  library://host:port/path:tags
+//	library:path:tags
+//	library:/path:tags
+//	library:///path:tags
+//	library://host/path:tags
+//	library://host:port/path:tags
 //
 // The tags component is a comma-separated list of one or more tags.
 type Ref struct {

--- a/client/search.go
+++ b/client/search.go
@@ -26,14 +26,14 @@ import (
 //
 // Match all collections with name "thename":
 //
-//     c.Search(ctx, map[string]string{"value": "thename"})
+//	c.Search(ctx, map[string]string{"value": "thename"})
 //
 // Match all images with name "imagename" and arch "amd64"
 //
-//     c.Search(ctx, map[string]string{
-//         "value": "imagename",
-//         "arch": "amd64"
-//     })
+//	c.Search(ctx, map[string]string{
+//	    "value": "imagename",
+//	    "arch": "amd64"
+//	})
 //
 // Note: if 'arch' and/or 'signed' are specified, the search is limited in
 // scope only to the "Image" collection.

--- a/client/util.go
+++ b/client/util.go
@@ -133,7 +133,8 @@ func PrettyPrint(v interface{}) {
 }
 
 // ImageHash returns the appropriate hash for a provided image file
-//   e.g. sif.<uuid> or sha256.<sha256>
+//
+//	e.g. sif.<uuid> or sha256.<sha256>
 func ImageHash(filePath string) (result string, err error) {
 	// Currently using sha256 always
 	// TODO - use sif uuid for sif files!


### PR DESCRIPTION
This pulls in the following PR from sylabs/scs-client-library, syncing up to their version v1.3.4:
- sylabs/scs-library-client#154

It includes changes to golangci-lint from after 1.3.4, needed in order to pass CI tests:
- sylabs/scs-library-client#156

The security fix note from v1.3.4:
> After release, the change in this version was identified as a fix for [CVE-2022-23538](https://github.com/sylabs/scs-library-client/security/advisories/GHSA-7p8m-22h4-9pj7) - User credentials leaked to third-party service via HTTP redirect.
> 
> See [GHSA-7p8m-22h4-9pj7](https://github.com/sylabs/scs-library-client/security/advisories/GHSA-7p8m-22h4-9pj7) for full details.