### PR TITLE
chore: enable dependabot for v1 branch, from sylabs199

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  target-branch: v1
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This pulls in
- sylabs/scs-library-client#199

With original PR description of
> Not currently covered...
