### PR TITLE
Remove obsolete DownloadImage() function, from sylabs159

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -138,10 +138,10 @@ func (c *Client) setTags(ctx context.Context, containerID, imageID string, tags 
 	}
 
 	for _, tag := range tags {
-		c.Logger.Logf("Setting tag %s", tag)
+		c.logger.Logf("Setting tag %s", tag)
 
 		if _, ok := existingTags[tag]; ok {
-			c.Logger.Logf("%s replaces an existing tag", tag)
+			c.logger.Logf("%s replaces an existing tag", tag)
 		}
 
 		imgTag := ImageTag{
@@ -159,12 +159,12 @@ func (c *Client) setTags(ctx context.Context, containerID, imageID string, tags 
 // getTags returns a tag map for the specified containerID
 func (c *Client) getTags(ctx context.Context, containerID string) (TagMap, error) {
 	url := fmt.Sprintf("v1/tags/%s", containerID)
-	c.Logger.Logf("getTags calling %s", url)
+	c.logger.Logf("getTags calling %s", url)
 	req, err := c.newRequest(ctx, http.MethodGet, url, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request to server:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -187,7 +187,7 @@ func (c *Client) getTags(ctx context.Context, containerID string) (TagMap, error
 // setTag sets tag on specified containerID
 func (c *Client) setTag(ctx context.Context, containerID string, t ImageTag) error {
 	url := "v1/tags/" + containerID
-	c.Logger.Logf("setTag calling %s", url)
+	c.logger.Logf("setTag calling %s", url)
 	s, err := json.Marshal(t)
 	if err != nil {
 		return fmt.Errorf("error encoding object to JSON:\n\t%v", err)
@@ -196,7 +196,7 @@ func (c *Client) setTag(ctx context.Context, containerID string, t ImageTag) err
 	if err != nil {
 		return fmt.Errorf("error creating POST request:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -220,10 +220,10 @@ func (c *Client) setTagsV2(ctx context.Context, containerID, arch string, imageI
 	}
 
 	for _, tag := range tags {
-		c.Logger.Logf("Setting tag %s", tag)
+		c.logger.Logf("Setting tag %s", tag)
 
 		if _, ok := existingTags[arch][tag]; ok {
-			c.Logger.Logf("%s replaces an existing tag for arch %s", tag, arch)
+			c.logger.Logf("%s replaces an existing tag for arch %s", tag, arch)
 		}
 
 		imgTag := ArchImageTag{
@@ -242,12 +242,12 @@ func (c *Client) setTagsV2(ctx context.Context, containerID, arch string, imageI
 // getTagsV2 returns a arch->tag map for the specified containerID
 func (c *Client) getTagsV2(ctx context.Context, containerID string) (ArchTagMap, error) {
 	url := fmt.Sprintf("v2/tags/%s", containerID)
-	c.Logger.Logf("getTagsV2 calling %s", url)
+	c.logger.Logf("getTagsV2 calling %s", url)
 	req, err := c.newRequest(ctx, http.MethodGet, url, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request to server:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request to server:\n\t%v", err)
 	}
@@ -270,7 +270,7 @@ func (c *Client) getTagsV2(ctx context.Context, containerID string) (ArchTagMap,
 // setTag sets an arch->tag on specified containerID
 func (c *Client) setTagV2(ctx context.Context, containerID string, t ArchImageTag) error {
 	url := "v2/tags/" + containerID
-	c.Logger.Logf("setTag calling %s", url)
+	c.logger.Logf("setTag calling %s", url)
 	s, err := json.Marshal(t)
 	if err != nil {
 		return fmt.Errorf("error encoding object to JSON:\n\t%v", err)
@@ -279,7 +279,7 @@ func (c *Client) setTagV2(ctx context.Context, containerID string, t ArchImageTa
 	if err != nil {
 		return fmt.Errorf("error creating POST request:\n\t%v", err)
 	}
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("error making request to server:\n\t%v", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -35,16 +35,11 @@ var DefaultConfig = &Config{}
 
 // Client describes the client details.
 type Client struct {
-	// Base URL of the service.
-	BaseURL *url.URL
-	// Auth token to include in the Authorization header of each request (if supplied).
-	AuthToken string
-	// User agent to include in each request (if supplied).
-	UserAgent string
-	// HTTPClient to use to make HTTP requests.
-	HTTPClient *http.Client
-	// Logger to be used when output is generated
-	Logger log.Logger
+	baseURL    *url.URL
+	authToken  string
+	userAgent  string
+	httpClient *http.Client
+	logger     log.Logger
 }
 
 const defaultBaseURL = ""
@@ -81,22 +76,22 @@ func NewClient(cfg *Config) (*Client, error) {
 	}
 
 	c := &Client{
-		BaseURL:   baseURL,
-		AuthToken: cfg.AuthToken,
-		UserAgent: cfg.UserAgent,
+		baseURL:   baseURL,
+		authToken: cfg.AuthToken,
+		userAgent: cfg.UserAgent,
 	}
 
 	// Set HTTP client
 	if cfg.HTTPClient != nil {
-		c.HTTPClient = cfg.HTTPClient
+		c.httpClient = cfg.HTTPClient
 	} else {
-		c.HTTPClient = http.DefaultClient
+		c.httpClient = http.DefaultClient
 	}
 
 	if cfg.Logger != nil {
-		c.Logger = cfg.Logger
+		c.logger = cfg.Logger
 	} else {
-		c.Logger = log.DefaultLogger
+		c.logger = log.DefaultLogger
 	}
 
 	return c, nil
@@ -104,7 +99,7 @@ func NewClient(cfg *Config) (*Client, error) {
 
 // newRequest returns a new Request given a method, relative path, rawQuery, and (optional) body.
 func (c *Client) newRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Request, error) {
-	u := c.BaseURL.ResolveReference(&url.URL{
+	u := c.baseURL.ResolveReference(&url.URL{
 		Path:     path,
 		RawQuery: rawQuery,
 	})
@@ -114,13 +109,13 @@ func (c *Client) newRequest(ctx context.Context, method, path, rawQuery string, 
 		return nil, err
 	}
 
-	if v := c.AuthToken; v != "" {
+	if v := c.authToken; v != "" {
 		if err := (bearerTokenCredentials{authToken: v}).ModifyRequest(r); err != nil {
 			return nil, err
 		}
 	}
 
-	if v := c.UserAgent; v != "" {
+	if v := c.userAgent; v != "" {
 		r.Header.Set("User-Agent", v)
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -102,9 +102,14 @@ func NewClient(cfg *Config) (*Client, error) {
 	return c, nil
 }
 
-// newRequestWithURL returns a new Request given a method, url, and (optional) body.
-func (c *Client) newRequestWithURL(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
-	r, err := http.NewRequestWithContext(ctx, method, url, body)
+// newRequest returns a new Request given a method, relative path, rawQuery, and (optional) body.
+func (c *Client) newRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Request, error) {
+	u := c.BaseURL.ResolveReference(&url.URL{
+		Path:     path,
+		RawQuery: rawQuery,
+	})
+
+	r, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -120,13 +125,4 @@ func (c *Client) newRequestWithURL(ctx context.Context, method, url string, body
 	}
 
 	return r, nil
-}
-
-// newRequest returns a new Request given a method, relative path, rawQuery, and (optional) body.
-func (c *Client) newRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Request, error) {
-	u := c.BaseURL.ResolveReference(&url.URL{
-		Path:     path,
-		RawQuery: rawQuery,
-	})
-	return c.newRequestWithURL(ctx, method, u.String(), body)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -68,19 +68,19 @@ func TestNewClient(t *testing.T) {
 			}
 
 			if err == nil {
-				if got, want := c.BaseURL.String(), tt.wantURL; got != want {
+				if got, want := c.baseURL.String(), tt.wantURL; got != want {
 					t.Errorf("got host %v, want %v", got, want)
 				}
 
-				if got, want := c.AuthToken, tt.wantAuthToken; got != want {
+				if got, want := c.authToken, tt.wantAuthToken; got != want {
 					t.Errorf("got auth token %v, want %v", got, want)
 				}
 
-				if got, want := c.UserAgent, tt.wantUserAgent; got != want {
+				if got, want := c.userAgent, tt.wantUserAgent; got != want {
 					t.Errorf("got user agent %v, want %v", got, want)
 				}
 
-				if got, want := c.HTTPClient, tt.wantHTTPClient; got != want {
+				if got, want := c.httpClient, tt.wantHTTPClient; got != want {
 					t.Errorf("got HTTP client %v, want %v", got, want)
 				}
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,8 +7,13 @@ package client
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
+	"encoding/binary"
 	"io"
+	"log"
+	math_rand "math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 )
@@ -191,4 +196,19 @@ func TestNewRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func seedRandomNumberGenerator() {
+	var b [8]byte
+	if _, err := crypto_rand.Read(b[:]); err != nil {
+		log.Fatalf("error seeding random number generator: %v", err)
+	}
+	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+}
+
+func TestMain(m *testing.M) {
+	// Total overkill seeding the random number generator
+	seedRandomNumberGenerator()
+
+	os.Exit(m.Run())
 }

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -67,7 +67,7 @@ func (c *Client) multipartDownload(ctx context.Context, u string, creds credenti
 
 	// Create download part workers
 	for n := uint(0); n < spec.Concurrency; n++ {
-		g.Go(c.ociDownloadWorker(ctx, u, creds, ch, pb))
+		g.Go(c.downloadWorker(ctx, u, creds, ch, pb))
 	}
 
 	// Add part download requests
@@ -84,11 +84,11 @@ func (c *Client) multipartDownload(ctx context.Context, u string, creds credenti
 	return g.Wait()
 }
 
-func (c *Client) ociDownloadWorker(ctx context.Context, u string, creds credentials, ch chan filePartDescriptor, pb ProgressBar) func() error {
+func (c *Client) downloadWorker(ctx context.Context, u string, creds credentials, ch chan filePartDescriptor, pb ProgressBar) func() error {
 	return func() error {
 		// Iterate on channel 'ch' to handle download part requests
 		for ps := range ch {
-			written, err := c.ociDownloadBlobPart(ctx, creds, u, &ps)
+			written, err := c.downloadBlobPart(ctx, creds, u, &ps)
 			if err != nil {
 				// Cleanly abort progress bar on error
 				pb.Abort(true)
@@ -103,7 +103,7 @@ func (c *Client) ociDownloadWorker(ctx context.Context, u string, creds credenti
 	}
 }
 
-func (c *Client) ociDownloadBlobPart(ctx context.Context, creds credentials, u string, ps *filePartDescriptor) (int64, error) {
+func (c *Client) downloadBlobPart(ctx context.Context, creds credentials, u string, ps *filePartDescriptor) (int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return 0, err

--- a/client/downloader.go
+++ b/client/downloader.go
@@ -58,7 +58,7 @@ func (c *Client) multipartDownload(ctx context.Context, u string, creds credenti
 	// Calculate # of parts
 	parts := uint(1 + (size-1)/spec.PartSize)
 
-	c.Logger.Logf("size: %d, parts: %d, streams: %d, partsize: %d", size, parts, spec.Concurrency, spec.PartSize)
+	c.logger.Logf("size: %d, parts: %d, streams: %d, partsize: %d", size, parts, spec.Concurrency, spec.PartSize)
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -117,7 +117,7 @@ func (c *Client) ociDownloadBlobPart(ctx context.Context, creds credentials, u s
 
 	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", ps.start, ps.end))
 
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/client/downloader_test.go
+++ b/client/downloader_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -17,6 +17,16 @@ import (
 	"strings"
 	"sync"
 	"testing"
+)
+
+const (
+	basicAuthUsername = "user"
+	basicAuthPassword = "password"
+)
+
+var (
+	testLogger = &stdLogger{}
+	creds      = &basicCredentials{username: basicAuthUsername, password: basicAuthPassword}
 )
 
 type inMemoryBuffer struct {
@@ -49,6 +59,19 @@ func (l *stdLogger) Logf(f string, v ...interface{}) {
 	log.Printf(f, v...)
 }
 
+func TestParseContentRange(t *testing.T) {
+	const hdr = "bytes 0-1000/1000"
+
+	size, err := parseContentRange(hdr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := size, int64(1000); got != want {
+		t.Fatalf("unexpected content length: got %v, want %v", got, want)
+	}
+}
+
 func parseRangeHeader(_ *testing.T, val string) (int64, int64) {
 	if val == "" {
 		return 0, 0
@@ -65,16 +88,6 @@ func parseRangeHeader(_ *testing.T, val string) (int64, int64) {
 
 	return start, end
 }
-
-const (
-	basicAuthUsername = "user"
-	basicAuthPassword = "password"
-)
-
-var (
-	testLogger = &stdLogger{}
-	creds      = &basicCredentials{username: basicAuthUsername, password: basicAuthPassword}
-)
 
 func TestMultistreamDownloader(t *testing.T) {
 	const src = "123456789012345678901234567890"

--- a/client/oci.go
+++ b/client/oci.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -48,11 +48,11 @@ func (c *Client) ociRegistryAuth(ctx context.Context, name string, accessTypes [
 		return nil, nil, err
 	}
 
-	if c.UserAgent != "" {
-		req.Header.Set("User-Agent", c.UserAgent)
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
 	}
 
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error determining direct OCI registry access: %w", err)
 	}
@@ -629,9 +629,9 @@ func (c *Client) newOCIRegistry(ctx context.Context, name string, accessTypes []
 	}
 
 	// Download directly from OCI registry
-	c.Logger.Logf("Using OCI registry endpoint %v", registryURI)
+	c.logger.Logf("Using OCI registry endpoint %v", registryURI)
 
-	return &ociRegistry{baseURL: registryURI, httpClient: c.HTTPClient, logger: c.Logger}, creds, nil
+	return &ociRegistry{baseURL: registryURI, httpClient: c.httpClient, logger: c.logger}, creds, nil
 }
 
 func (c *Client) ociDownloadImage(ctx context.Context, arch, name, tag string, w io.WriterAt, spec *Downloader, pb ProgressBar) error {
@@ -714,7 +714,7 @@ func (c *Client) ociUploadImage(ctx context.Context, r io.Reader, size int64, na
 		}
 
 	} else {
-		c.Logger.Logf("Skipping image blob upload (matching hash exists)")
+		c.logger.Logf("Skipping image blob upload (matching hash exists)")
 
 		id = imageDigest
 
@@ -754,7 +754,7 @@ func (c *Client) ociUploadImage(ctx context.Context, r io.Reader, size int64, na
 
 	// Add tags
 	for _, ref := range tags {
-		c.Logger.Logf("Tag: %v", ref)
+		c.logger.Logf("Tag: %v", ref)
 
 		if _, err := reg.uploadManifest(ctx, creds, name, ref, idx, v1.MediaTypeImageIndex); err != nil {
 			return fmt.Errorf("error uploading index")

--- a/client/pull.go
+++ b/client/pull.go
@@ -165,25 +165,25 @@ func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch
 		return err
 	}
 
-	c.Logger.Log("Fallback to (legacy) library download")
+	c.logger.Log("Fallback to (legacy) library download")
 
 	return c.legacyDownloadImage(ctx, arch, name, tag, dst, spec, pb)
 }
 
 func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string, dst io.WriterAt, spec *Downloader, pb ProgressBar) error {
 	if arch != "" && !c.apiAtLeast(ctx, APIVersionV2ArchTags) {
-		c.Logger.Log("This library does not support architecture specific tags")
-		c.Logger.Log("The image returned may not be the requested architecture")
+		c.logger.Log("This library does not support architecture specific tags")
+		c.logger.Log("The image returned may not be the requested architecture")
 	}
 
 	apiPath := fmt.Sprintf("v1/imagefile/%v:%v", name, tag)
 	q := url.Values{}
 	q.Add("arch", arch)
 
-	c.Logger.Logf("Pulling from URL: %s", apiPath)
+	c.logger.Logf("Pulling from URL: %s", apiPath)
 
 	customHTTPClient := &http.Client{
-		Transport: c.HTTPClient.Transport,
+		Transport: c.httpClient.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if req.Response.StatusCode == http.StatusSeeOther {
 				return http.ErrUseLastResponse
@@ -194,8 +194,8 @@ func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string
 			}
 			return nil
 		},
-		Jar:     c.HTTPClient.Jar,
-		Timeout: c.HTTPClient.Timeout,
+		Jar:     c.httpClient.Jar,
+		Timeout: c.httpClient.Timeout,
 	}
 
 	req, err := c.newRequest(ctx, http.MethodGet, apiPath, q.Encode(), nil)
@@ -216,7 +216,7 @@ func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string
 	if res.StatusCode == http.StatusOK {
 		// Library endpoint does not provide HTTP redirection response, treat as single stream download
 
-		c.Logger.Log("Library endpoint does not support concurrent downloads; reverting to single stream")
+		c.logger.Log("Library endpoint does not support concurrent downloads; reverting to single stream")
 
 		size, err := parseContentLengthHeader(res.Header.Get("Content-Length"))
 		if err != nil {
@@ -242,9 +242,9 @@ func (c *Client) legacyDownloadImage(ctx context.Context, arch, name, tag string
 	}
 
 	var creds credentials
-	if c.AuthToken != "" && samehost(c.BaseURL, redirectURL) {
+	if c.authToken != "" && samehost(c.baseURL, redirectURL) {
 		// Only include credentials if redirected to same host as base URL
-		creds = bearerTokenCredentials{authToken: c.AuthToken}
+		creds = bearerTokenCredentials{authToken: c.authToken}
 	}
 
 	// Use redirect URL to download artifact
@@ -286,7 +286,7 @@ func (c *Client) download(_ context.Context, w io.WriterAt, r io.Reader, size in
 		return err
 	}
 
-	c.Logger.Logf("Downloaded %v byte(s)", written)
+	c.logger.Logf("Downloaded %v byte(s)", written)
 
 	return nil
 }

--- a/client/pull.go
+++ b/client/pull.go
@@ -70,7 +70,7 @@ type ProgressBar interface {
 	Wait()
 }
 
-// ConcurrentDownloadImage implements a multi-part (concurrent) downloader for
+// DownloadImage implements a multi-part (concurrent) downloader for
 // Cloud Library images. spec is used to define transfer parameters. pb is an
 // optional progress bar interface.  If pb is nil, NoopProgressBar is used.
 //
@@ -78,7 +78,7 @@ type ProgressBar interface {
 // only files larger than Downloader.PartSize. It will automatically adjust the
 // concurrency for source files that do not meet minimum size for multi-part
 // downloads.
-func (c *Client) ConcurrentDownloadImage(ctx context.Context, dst *os.File, arch, path, tag string, spec *Downloader, pb ProgressBar) error {
+func (c *Client) DownloadImage(ctx context.Context, dst *os.File, arch, path, tag string, spec *Downloader, pb ProgressBar) error {
 	if pb == nil {
 		pb = &NoopProgressBar{}
 	}

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -8,7 +8,6 @@ package client
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -84,16 +83,6 @@ func generateSampleData(t *testing.T) []byte {
 	return sampleBytes
 }
 
-func seedRandomNumberGenerator(t *testing.T) {
-	t.Helper()
-
-	var b [8]byte
-	if _, err := crypto_rand.Read(b[:]); err != nil {
-		t.Fatalf("error seeding random number generator: %v", err)
-	}
-	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
-}
-
 // mockLibraryServer returns *httptest.Server that mocks Cloud Library server; in particular,
 // it has handlers for /version, /v1/images, /v1/imagefile, and /v1/imagepart
 func mockLibraryServer(t *testing.T, sampleBytes []byte, size int64, multistream bool) *httptest.Server {
@@ -163,9 +152,6 @@ func TestLegacyDownloadImage(t *testing.T) {
 		{"SingleStream", false},
 		{"MultiStream", true},
 	}
-
-	// Total overkill seeding the random number generator
-	seedRandomNumberGenerator(t)
 
 	for _, tt := range tests {
 		tt := tt

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -21,19 +21,6 @@ import (
 	math_rand "math/rand"
 )
 
-func TestParseContentRange(t *testing.T) {
-	const hdr = "bytes 0-1000/1000"
-
-	size, err := parseContentRange(hdr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if got, want := size, int64(1000); got != want {
-		t.Fatalf("unexpected content length: got %v, want %v", got, want)
-	}
-}
-
 func TestParseContentLengthHeader(t *testing.T) {
 	t.Parallel()
 

--- a/client/pull_test.go
+++ b/client/pull_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -6,17 +6,13 @@
 package client
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,123 +21,6 @@ import (
 
 	math_rand "math/rand"
 )
-
-type mockRawService struct {
-	t           *testing.T
-	code        int
-	testFile    string
-	reqCallback func(*http.Request, *testing.T)
-	httpAddr    string
-	httpPath    string
-	httpServer  *httptest.Server
-	baseURI     string
-}
-
-func (m *mockRawService) Run() {
-	mux := http.NewServeMux()
-	mux.HandleFunc(m.httpPath, m.ServeHTTP)
-	m.httpServer = httptest.NewServer(mux)
-	m.httpAddr = m.httpServer.Listener.Addr().String()
-	m.baseURI = "http://" + m.httpAddr
-}
-
-func (m *mockRawService) Stop() {
-	m.httpServer.Close()
-}
-
-func (m *mockRawService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if m.reqCallback != nil {
-		m.reqCallback(r, m.t)
-	}
-	w.WriteHeader(m.code)
-	inFile, err := os.Open(m.testFile)
-	if err != nil {
-		m.t.Errorf("error opening file %v:", err)
-	}
-	defer inFile.Close()
-
-	_, err = io.Copy(w, bufio.NewReader(inFile))
-	if err != nil {
-		m.t.Errorf("Test HTTP server unable to output file: %v", err)
-	}
-}
-
-func Test_DownloadImage(t *testing.T) {
-	f, err := os.CreateTemp("", "test")
-	if err != nil {
-		t.Fatalf("Error creating a temporary file for testing")
-	}
-	tempFile := f.Name()
-	f.Close()
-	os.Remove(tempFile)
-
-	tests := []struct {
-		name         string
-		arch         string
-		path         string
-		tag          string
-		outFile      string
-		code         int
-		testFile     string
-		tokenFile    string
-		checkContent bool
-		expectError  bool
-	}{
-		{"Bad library ref", "amd64", "entity/collection/im,age", "tag", tempFile, http.StatusBadRequest, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Server error", "amd64", "entity/collection/image", "tag", tempFile, http.StatusInternalServerError, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Tags in path", "amd64", "entity/collection/image:tag", "anothertag", tempFile, http.StatusOK, "test_data/test_sha256", "test_data/test_token", false, true},
-		{"Good Download", "amd64", "entity/collection/image", "tag", tempFile, http.StatusOK, "test_data/test_sha256", "test_data/test_token", true, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := mockRawService{
-				t:        t,
-				code:     tt.code,
-				testFile: tt.testFile,
-				httpPath: fmt.Sprintf("/v1/imagefile/%s:%s", tt.path, tt.tag),
-			}
-
-			m.Run()
-			defer m.Stop()
-
-			c, err := NewClient(&Config{AuthToken: tt.tokenFile, BaseURL: m.baseURI})
-			if err != nil {
-				t.Errorf("Error initializing client: %v", err)
-			}
-
-			out, err := os.OpenFile(tt.outFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o777)
-			if err != nil {
-				t.Errorf("Error opening file %s for writing: %v", tt.outFile, err)
-			}
-
-			err = c.DownloadImage(context.Background(), out, tt.arch, tt.path, tt.tag, nil)
-
-			out.Close()
-
-			if err != nil && !tt.expectError {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if err == nil && tt.expectError {
-				t.Errorf("Unexpected success. Expected error.")
-			}
-
-			if tt.checkContent {
-				fileContent, err := os.ReadFile(tt.outFile)
-				if err != nil {
-					t.Errorf("Error reading test output file: %v", err)
-				}
-				testContent, err := os.ReadFile(tt.testFile)
-				if err != nil {
-					t.Errorf("Error reading test file: %v", err)
-				}
-				if !bytes.Equal(fileContent, testContent) {
-					t.Errorf("File contains '%v' - expected '%v'", fileContent, testContent)
-				}
-			}
-		})
-	}
-}
 
 func TestParseContentRange(t *testing.T) {
 	const hdr = "bytes 0-1000/1000"

--- a/client/restclient.go
+++ b/client/restclient.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2018-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE.md file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -22,17 +22,17 @@ import (
 var ErrNotFound = errors.New("not found")
 
 func (c *Client) apiGet(ctx context.Context, path string) (objJSON []byte, err error) {
-	c.Logger.Logf("apiGet calling %s", path)
+	c.logger.Logf("apiGet calling %s", path)
 	return c.doGETRequest(ctx, path)
 }
 
 func (c *Client) apiCreate(ctx context.Context, url string, o interface{}) (objJSON []byte, err error) {
-	c.Logger.Logf("apiCreate calling %s", url)
+	c.logger.Logf("apiCreate calling %s", url)
 	return c.doPOSTRequest(ctx, url, o)
 }
 
 func (c *Client) apiUpdate(ctx context.Context, url string, o interface{}) (objJSON []byte, err error) {
-	c.Logger.Logf("apiUpdate calling %s", url)
+	c.logger.Logf("apiUpdate calling %s", url)
 	return c.doPUTRequest(ctx, url, o)
 }
 
@@ -75,7 +75,7 @@ func (c *Client) commonRequestHandler(ctx context.Context, method string, path s
 		return []byte{}, fmt.Errorf("error creating %s request:\n\t%v", method, err)
 	}
 
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return []byte{}, fmt.Errorf("error making request to server:\n\t%v", err)
 	}

--- a/client/version.go
+++ b/client/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// Copyright (c) 2019-2023, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -34,7 +34,7 @@ func (c *Client) GetVersion(ctx context.Context) (vi VersionInfo, err error) {
 		return VersionInfo{}, err
 	}
 
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return VersionInfo{}, err
 	}
@@ -53,17 +53,17 @@ func (c *Client) apiAtLeast(ctx context.Context, reqVersion string) bool {
 	if err != nil || vi.APIVersion == "" {
 		// unable to get cloud-library server API version, fallback to lowest
 		// common denominator
-		c.Logger.Logf("Unable to determine remote API version: %v", err)
+		c.logger.Logf("Unable to determine remote API version: %v", err)
 		return false
 	}
 	v, err := semver.Make(vi.APIVersion)
 	if err != nil {
-		c.Logger.Logf("Unable to decode remote API version: %v", err)
+		c.logger.Logf("Unable to decode remote API version: %v", err)
 		return false
 	}
 	minRequiredVers, err := semver.Make(reqVersion)
 	if err != nil {
-		c.Logger.Logf("Unable to decode minimum required version: %v", err)
+		c.logger.Logf("Unable to decode minimum required version: %v", err)
 		return false
 	}
 	return v.GTE(minRequiredVers)


### PR DESCRIPTION
This pulls in
- sylabs/scs-container-library#159

with original PR description of
> Removes obsolete (Client).DownloadImage() function
>     * rename `ConcurrentDownloadImage()` to `DownloadImage()`
>     * rename unexported function `ociDownloadBlobPart` `downloadBlobPart()`
>     * unit test improvements
